### PR TITLE
[FIX] asd_stock_account: handle automatic journal creation that does not run if it does not match the active company

### DIFF
--- a/asd_stock_account/models/product.py
+++ b/asd_stock_account/models/product.py
@@ -41,7 +41,7 @@ class ProductProduct(models.Model):
             
             locations_domain = [
                     ("usage", "=", "internal"),
-                    ("company_id", "=", self.env.user.company_id.id),
+                    # ("company_id", "=", self.env.user.company_id.id),
                     ("id", "in", quant_loc_ids)
                 ]
             locations = location_obj.search(locations_domain)


### PR DESCRIPTION
Perbaikan isu pembentukan jurnal otomatis saat perubahan inventory valuation pada suatu product category. Sebelumnya pembentukan jurnal otomatis ini hanya akan ter-trigger jika company aktif sama dengan company produk-produk yang ada di dalam daftar product category terkait